### PR TITLE
Change EditCard attr names

### DIFF
--- a/sample/src/main/res/values/style_custom.xml
+++ b/sample/src/main/res/values/style_custom.xml
@@ -86,14 +86,14 @@
     </style>
 
     <style name="AcquiringEditCardStyle.Custom" parent="AcquiringEditCardStyle">
-        <item name="cursorColor">@color/custom_colorAccent</item>
+        <item name="acqCursorColor">@color/custom_colorAccent</item>
         <item name="android:textColorHint">@color/common_gray</item>
-        <item name="textColorInvalid">@color/custom_textColorInvalid</item>
-        <item name="numberHint">Custom Card Number</item>
-        <item name="dateHint">**/**</item>
-        <item name="cvcHint">***</item>
-        <item name="keyboardBackgroundColor">#222645</item>
-        <item name="keyboardKeyTextColor">#ffffff</item>
+        <item name="acqTextColorInvalid">@color/custom_textColorInvalid</item>
+        <item name="acqNumberHint">Custom Card Number</item>
+        <item name="acqDateHint">**/**</item>
+        <item name="acqCvcHint">***</item>
+        <item name="acqKeyboardBackgroundColor">#222645</item>
+        <item name="acqKeyboardKeyTextColor">#ffffff</item>
     </style>
 
     <style name="AcquiringTitleStyle.Custom" parent="AcquiringTitleTextStyle">

--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/EditCard.kt
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/EditCard.kt
@@ -282,17 +282,17 @@ internal class EditCard @JvmOverloads constructor(
                 textColor = getColor(R.styleable.EditCard_android_textColor, R.styleable.EditCard_android_textColor)
                 fontFamily = getString(R.styleable.EditCard_android_fontFamily)
                 textColorHint = getColor(R.styleable.EditCard_android_textColorHint, R.styleable.EditCard_android_textColorHint)
-                textColorInvalid = getColor(R.styleable.EditCard_textColorInvalid, Color.RED)
-                cursorColor = getColor(R.styleable.EditCard_cursorColor, typedValue.data)
+                textColorInvalid = getColor(R.styleable.EditCard_acqTextColorInvalid, Color.RED)
+                cursorColor = getColor(R.styleable.EditCard_acqCursorColor, typedValue.data)
 
-                cardNumberHint = getString(R.styleable.EditCard_numberHint) ?: "Card number"
-                cardDateHint = getString(R.styleable.EditCard_dateHint) ?: "MM/YY"
-                cardCvcHint = getString(R.styleable.EditCard_cvcHint) ?: "CVC"
+                cardNumberHint = getString(R.styleable.EditCard_acqNumberHint) ?: "Card number"
+                cardDateHint = getString(R.styleable.EditCard_acqDateHint) ?: "MM/YY"
+                cardCvcHint = getString(R.styleable.EditCard_acqCvcHint) ?: "CVC"
 
-                nextIconResId = getResourceId(R.styleable.EditCard_nextIcon, R.drawable.acq_icon_next)
-                scanIconResId = getResourceId(R.styleable.EditCard_scanIcon, R.drawable.acq_icon_scan_card)
+                nextIconResId = getResourceId(R.styleable.EditCard_acqNextIcon, R.drawable.acq_icon_next)
+                scanIconResId = getResourceId(R.styleable.EditCard_acqScanIcon, R.drawable.acq_icon_scan_card)
 
-                mode = EditCardMode.fromInt(getInteger(R.styleable.EditCard_mode, DEFAULT.value))
+                mode = EditCardMode.fromInt(getInteger(R.styleable.EditCard_acqMode, DEFAULT.value))
             }
         } finally {
             attrsArray.recycle()

--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/keyboard/SecureKeyboard.kt
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/keyboard/SecureKeyboard.kt
@@ -61,8 +61,8 @@ internal class SecureKeyboard @JvmOverloads constructor(
         try {
             attrsArray.apply {
                 val defaultColor = ContextCompat.getColor(context, R.color.acq_colorKeyboardBackground)
-                keyboardBackgroundColor = getColor(R.styleable.SecureKeyboard_keyboardBackgroundColor, defaultColor)
-                keyboardKeyTextColor = getColor(R.styleable.SecureKeyboard_keyboardKeyTextColor, Color.WHITE)
+                keyboardBackgroundColor = getColor(R.styleable.SecureKeyboard_acqKeyboardBackgroundColor, defaultColor)
+                keyboardKeyTextColor = getColor(R.styleable.SecureKeyboard_acqKeyboardKeyTextColor, Color.WHITE)
             }
         } finally {
             attrsArray.recycle()

--- a/ui/src/main/res/values/attrs_edit_card_view.xml
+++ b/ui/src/main/res/values/attrs_edit_card_view.xml
@@ -25,17 +25,17 @@
         <attr name="android:enabled" />
         <attr name="android:textColorHint" />
 
-        <attr name="numberHint" format="string|reference" />
-        <attr name="dateHint" format="string|reference" />
-        <attr name="cvcHint" format="string|reference" />
+        <attr name="acqNumberHint" format="string|reference" />
+        <attr name="acqDateHint" format="string|reference" />
+        <attr name="acqCvcHint" format="string|reference" />
 
-        <attr name="scanIcon" format="reference" />
-        <attr name="nextIcon" format="reference" />
+        <attr name="acqScanIcon" format="reference" />
+        <attr name="acqNextIcon" format="reference" />
 
-        <attr name="textColorInvalid" format="color|reference" />
-        <attr name="cursorColor" format="color|reference" />
+        <attr name="acqTextColorInvalid" format="color|reference" />
+        <attr name="acqCursorColor" format="color|reference" />
 
-        <attr name="mode" format="enum">
+        <attr name="acqMode" format="enum">
             <enum name="default_edit" value="1" />
             <enum name="without_cvc" value="2" />
             <enum name="number_only" value="4" />
@@ -45,7 +45,7 @@
     </declare-styleable>
 
     <declare-styleable name="SecureKeyboard">
-        <attr name="keyboardBackgroundColor" format="color|reference"/>
-        <attr name="keyboardKeyTextColor" format="color|reference"/>
+        <attr name="acqKeyboardBackgroundColor" format="color|reference"/>
+        <attr name="acqKeyboardKeyTextColor" format="color|reference"/>
     </declare-styleable>
 </resources>

--- a/ui/src/main/res/values/styles.xml
+++ b/ui/src/main/res/values/styles.xml
@@ -127,9 +127,9 @@
 
     <style name="AcquiringEditCardStyle">
         <item name="android:textColorHint">@color/acq_colorHint</item>
-        <item name="textColorInvalid">@color/acq_colorTextInvalid</item>
-        <item name="keyboardBackgroundColor">@color/acq_colorKeyboardBackground</item>
-        <item name="keyboardKeyTextColor">@color/acq_colorKeyText</item>
+        <item name="acqTextColorInvalid">@color/acq_colorTextInvalid</item>
+        <item name="acqKeyboardBackgroundColor">@color/acq_colorKeyboardBackground</item>
+        <item name="acqKeyboardKeyTextColor">@color/acq_colorKeyText</item>
     </style>
 
     <style name="AcquiringTitleTextStyle">


### PR DESCRIPTION
В больших проектах велик шанс получить компиляционную ошибку о повторении атрибутов при коллизии со старыми библиотеками которые не поддерживают AndroidX, идея в том чтобы привести атрибуты к одному неймингу и свести такие компиляционные ошибки к минимуму.

Как пример при добавлении библиотеки приложение не собирается вместе с библиотекой https://github.com/chthai64/SwipeRevealLayout, из-за дублирования атрибута mode в EditCard со своим атрибутом с тем же именем.

compileSdkVersion 30
buildToolsVersion '30.0.3'
minSdkVersion 23