### PR TITLE
Убрать валидацию истекшего срока действия карт

### DIFF
--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/EditCard.kt
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/ui/customview/editcard/EditCard.kt
@@ -921,7 +921,9 @@ internal class EditCard @JvmOverloads constructor(
     private fun isValid(field: EditCardField): Boolean {
         return when (field) {
             CARD_NUMBER -> CardValidator.validateCardNumber(cardNumber) || checkFlags(FLAG_MASKED_NUMBER)
-            EXPIRE_DATE -> CardValidator.validateExpireDate(cardDate, validateNotExpired)
+            // В марте 2022 года многие банки продлили сроки действия карт. Валидация истекшего срока действия проводиться не должна. 
+            // Другие сервисы эквайринга не проводят валидацию карт на предмет истекшего срока действия
+            // EXPIRE_DATE -> CardValidator.validateExpireDate(cardDate, validateNotExpired)
             SECURE_CODE -> CardValidator.validateSecurityCode(cardCvc)
         }
     }


### PR DESCRIPTION
В марте 2022 года многие банки продлили сроки действия карт. Валидация истекшего срока действия проводиться не должна. 
Например, Альфа-банк продлил все карты Visa и Mastercard до декабря 2028 года.
При этом, на форме оплаты необходимо вводить тот срок действия, который указан на карте, даже если он истекший.
Другие сервисы эквайринга не проводят валидацию карт на предмет истекшего срока действия